### PR TITLE
make api call https

### DIFF
--- a/src/javascript/post_getter.coffee
+++ b/src/javascript/post_getter.coffee
@@ -1,8 +1,8 @@
 $ = require 'jquery'
 
 module.exports = PostGetter =
-  # api: "http://kinja.com/api/core/post"
-  api: "http://kinja.com/api/core/corepost/getList"
+  # api: "https://kinja.com/api/core/post"
+  api: "https://kinja.com/api/core/corepost/getList"
 
   isLink: (link) ->
     link = @cleanLink(link)


### PR DESCRIPTION
let's switch over the API call for the related widget for kinja.com to https! this is to make sure that the widget will keep working under https.
